### PR TITLE
Upgrade jekyll to latest

### DIFF
--- a/jekyll-agency.gemspec
+++ b/jekyll-agency.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(assets|_(data|includes|layouts|sass)/|(LICENSE|README|index|404|legal)((\.(txt|md|markdown|html)|$)))}i)
   end
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll", "~> 4.0"
   
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

Upgrading jekyll to ~> 4.0

## Context

currently 4.0.0 is the latest, a quick build doesn't break anything