### PR TITLE
fix AJAX formspree error on GH pages

### DIFF
--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -25,6 +25,7 @@ $(function() {
       $.ajax({
         url: url,
         type: "POST",
+	dataType: "json",      
         data: {
           name: name,
           phone: phone,


### PR DESCRIPTION
add  -- > dataType: "json" to ajax request body

<!--
  Choose one of the following by uncommenting it:
-->
 This is a bug fix.

## Summary

adds {dataType: "json"} to formspree AJAX object, fixs redirect error on GH pages

## Context
