### PR TITLE
Automatically align items in timeline

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -30,30 +30,30 @@ timeline:
     title: "About" 
     text: "Lorem ipsum timeline"
     section: timeline
+    # left is the default
+    #start_align: "left"
     events:
       - title: "Our Humble Beginnings"
         year: "2009-2011"
         desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
         image: assets/img/timeline/1.jpg
         alt: 
-        align: left
       - title: "An Agency is Born"
         year: "March 2011"
         desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
         image: assets/img/timeline/2.jpg
         alt: 
-        align: right
       - title: "Jekyll Theme is created"
         year: "2019"
         desc: "Ravi Riley converted Agency, a Bootstrap-based theme, into a Jekyll theme. The Jekyll theme can be installed as a Ruby gem, or remotely. For more information, visit the documentation."
         image: assets/img/timeline/3.jpg
         alt: image alt text
-        #align: #default is left       
       - title: "Title"
         year: "2009-2011"
         desc: "Your description here, **Markdown** is fully supported."
         image: assets/img/timeline/4.jpg
         alt: 
+        # you can enforce the aligment
         align: right
     end: "Be Part <br> of Our <br> Story!"
 

--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -10,12 +10,25 @@
       <div class="row">
         <div class="col-lg-12">
           <ul class="timeline">
-		  {%- for event in site.data.sitetext.timeline.events -%}
-            {% if event.align == "right" %}
-			<li class="timeline-inverted">
-			{% else %}
-			<li>
-			{% endif %}
+      {%- assign align = site.data.sitetext.timeline.start_align -%}
+      {%- for event in site.data.sitetext.timeline.events -%}
+            {%- if align == "right" -%}
+              {%- if event.align and event.align == "left" -%}
+                {%- assign align = "right" -%}
+                <li>
+              {%- else -%}
+                {%- assign align = "left" %}
+                <li class="timeline-inverted">
+              {% endif %}
+            {% else %}
+              {%- if event.align and event.align == "right" -%}
+                {%- assign align = "left" -%}
+                <li class="timeline-inverted">
+              {%- else -%}
+                {%- assign align = "right" %}
+                <li>
+              {% endif %}
+            {%- endif -%}
               <div class="timeline-image">
                 <img class="rounded-circle img-fluid" src="{{ event.image }}" alt="{{ event.alt | default: ""}}">
               </div>
@@ -38,7 +51,7 @@
               </div>
             </li>
 		  {% endif %}
-			
+
           </ul>
         </div>
       </div>


### PR DESCRIPTION
You can define:

timeline:
   start_align: "right"

and then the timeline starts aligned to right and then continue switching.
The default is:
   start_align: "left"

You can always enforce the order by:

 - title: "Title"
   year: "2009-2011"
   align: right

which will enforce the alignment to the right and the next one will continue on left.
