### PR TITLE
Attempting to add formspree_form_path site variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 #
 # This config file is meant for settings that affect your whole blog, values
 # which you are expected to set up once and rarely edit after that.
-# This file is *NOT* reloaded automatically when you use 'bundle exec jekyll serve'. 
+# This file is *NOT* reloaded automatically when you use 'bundle exec jekyll serve'.
 # If you change this file, please restart the server process.
 
 # Site settings
@@ -16,7 +16,7 @@ theme: jekyll-agency
 url    : "" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "" # the subpath of your site, e.g. /blog
 
-title      : Your Awesome Website 
+title      : Your Awesome Website
 email      : your-email@example.com #this is also the email contact forms will go to
 description: "Site description"
 author     : Your Name
@@ -31,3 +31,7 @@ collections:
   portfolio:
 
 markdown: kramdown
+
+# Uncomment following line to use Formspree form ID based URL instead of email based URL
+# Details: https://help.formspree.io/hc/en-us/articles/360017735154-How-to-prevent-spam
+# formspree_form_path: "f/a_form_id"

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -9,8 +9,8 @@
       </div>
       <div class="row">
         <div class="col-lg-12">
-          <form id="contactForm" action="https://formspree.io/{{ site.email }}" novalidate="novalidate" method="POST">
-		  <!--name="sentMessage"--> 
+          <form id="contactForm" action="https://formspree.io/{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}" novalidate="novalidate" method="POST">
+		  <!--name="sentMessage"-->
             <div class="row">
               <div class="col-md-6">
                 <div class="form-group">

--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -10,7 +10,7 @@ $(function() {
     submitSuccess: function($form, event) {
       event.preventDefault(); // prevent default submit behaviour
       // get values from FORM
-	  var url = "https://formspree.io/" + "{{ site.email }}";
+	  var url = "https://formspree.io/" + "{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}";
       var name = $("input#name").val();
       var email = $("input#email").val();
       var phone = $("input#phone").val();
@@ -25,7 +25,7 @@ $(function() {
       $.ajax({
         url: url,
         type: "POST",
-	dataType: "json",      
+	dataType: "json",
         data: {
           name: name,
           phone: phone,
@@ -33,7 +33,7 @@ $(function() {
           message: message
         },
         cache: false,
-        
+
 		success: function() {
           // Success message
           $('#success').html("<div class='alert alert-success'>");
@@ -46,7 +46,7 @@ $(function() {
           //clear all fields
           $('#contactForm').trigger("reset");
         },
-		
+
         error: function() {
           // Fail message
           $('#success').html("<div class='alert alert-danger'>");
@@ -57,7 +57,7 @@ $(function() {
           //clear all fields
           $('#contactForm').trigger("reset");
         },
-		
+
         complete: function() {
           setTimeout(function() {
             $this.prop("disabled", false); // Re-enable submit button when AJAX call is complete


### PR DESCRIPTION
possible fix for https://github.com/raviriley/agency-jekyll-theme/issues/10

Should maintain backwards compatibility if `formspree_form_path` is not set in older `_config.yml` installations.

Tested only locally, may need additional testing.

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

Formspree is phasing out legacy forms (email URLs).

`<form action="https://formspree.io/your@email.com" method="POST">` is considered to be a legacy URL. Newly created forms utilize `form_id` URL path like `<form action="https://formspree.io/f/a_form_id" method="POST">`

## Context
Formspree articles related to the upcoming change: https://help.formspree.io/hc/en-us/articles/360017735154-How-to-prevent-spam and https://help.formspree.io/hc/en-us/articles/360056076314
