### PR TITLE
Add SPANISH (ESPAÑOL) Language Support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,8 @@ author     : Your Name
   # path: assets\img\clients\creative-market.jpg
   # height: 60 #height in px, defaults to 52px
 
+locale: "en-US" # See available languages in _data/sitetext.yml
+
 analytics:
   google: #Google Analytics tracking code here
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,18 +1,54 @@
-nav:
-  - title: "Services"
-    section: services
+#
+# Work based on https://github.com/mmistakes/minimal-mistakes/blob/master/_data/ui-text.yml
+#
+# Configuration: Add to _config.yml
+# locale: "en-US"  [YOUR PREFERRED LOCALE]
+#
+# How to use:
+# {{ site.data.navigation[site.locale].nav.<var_name> | default: 'text' }}
 
-  - title: "Portfolio"
-    section: portfolio
-    
-  - title: "About"
-    section: timeline
+# English (default)
+# -----------------
+en: &DEFAULT_EN
+  nav:
+    - title: "Services"
+      section: services
+    - title: "Portfolio"
+      section: portfolio
+    - title: "About"
+      section: timeline
+    - title: "Team"
+      section: team
+    - title: "Contact"
+      section: contact
+    - title: "Theme Source"
+      url: https://github.com/raviriley/agency-jekyll-theme/
+en-US:
+  <<: *DEFAULT_EN
+en-CA:
+  <<: *DEFAULT_EN
+en-GB:
+  <<: *DEFAULT_EN
+en-AU:
+  <<: *DEFAULT_EN
 
-  - title: "Team"
-    section: team
-
-  - title: "Contact"
-    section: contact
-
-  - title: "Theme Source"
-    url: https://github.com/raviriley/agency-jekyll-theme/
+# Spanish
+# -------
+es: &DEFAULT_ES
+  nav:
+    - title: "Servicios"
+      section: servicios
+    - title: "Portafolio"
+      section: portafolio
+    - title: "Cronología"
+      section: cronologia
+    - title: "Equipo"
+      section: equipo
+    - title: "Contáctenos"
+      section: contacto
+    - title: "Fuente de la plantilla"
+      url: https://github.com/raviriley/agency-jekyll-theme/
+es-ES:
+  <<: *DEFAULT_ES
+es-CO:
+  <<: *DEFAULT_ES

--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -1,10 +1,22 @@
-header:
+#
+# Work based on https://github.com/mmistakes/minimal-mistakes/blob/master/_data/ui-text.yml
+#
+# Configuration: Add to _config.yml
+# locale: "en-US"  [YOUR PREFERRED LOCALE]
+#
+# How to use:
+# {{ site.data.ui-text[site.locale].<var_name> | default: 'text' }}
+
+# English (default)
+# -----------------
+en: &DEFAULT_EN
+  header:
     title: Welcome to our Studio!
     text: It's Nice To Meet You
     button: Tell Me More
     buttonlink: "#services"
 
-services:
+  services:
     title: "Services"
     text: "Lorem ipsum"
     section: services
@@ -14,20 +26,19 @@ services:
         icon: fas fa-shopping-cart #find more at https://fontawesome.com/icons
       - title: "Responsive Design"
         desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
-        icon: fas fa-laptop       
+        icon: fas fa-laptop
       - title: "[Markdown](https://en.wikipedia.org/wiki/Markdown)"
         desc: "Your description here, full **Markdown** support"
         icon: fab fa-markdown
 
-portfolio:
+  portfolio:
     title: "Portfolio"
     text: "Lorem ipsum dolor sit amet consectetur."
     section: portfolio
     closebutton: "Close Project"
-    
 
-timeline:
-    title: "About" 
+  timeline:
+    title: "About"
     text: "Lorem ipsum timeline"
     section: timeline
     # left is the default
@@ -37,12 +48,12 @@ timeline:
         year: "2009-2011"
         desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
         image: assets/img/timeline/1.jpg
-        alt: 
+        alt:
       - title: "An Agency is Born"
         year: "March 2011"
         desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
         image: assets/img/timeline/2.jpg
-        alt: 
+        alt:
       - title: "Jekyll Theme is created"
         year: "2019"
         desc: "Ravi Riley converted Agency, a Bootstrap-based theme, into a Jekyll theme. The Jekyll theme can be installed as a Ruby gem, or remotely. For more information, visit the documentation."
@@ -52,17 +63,17 @@ timeline:
         year: "2009-2011"
         desc: "Your description here, **Markdown** is fully supported."
         image: assets/img/timeline/4.jpg
-        alt: 
-        # you can enforce the aligment
+        alt:
+        # you can enforce the alignment
         align: right
     end: "Be Part <br> of Our <br> Story!"
 
-about:
+  about:
     title: "About Us"
     text: "our story"
     section: about
 
-clients:
+  clients:
     section: clients
     max-height: 100px
     horizontal-scrolling: "" #"yes/no"
@@ -79,8 +90,8 @@ clients:
       - title: "Creative Market"
         url: https://github.com/raviriley/agency-jekyll-theme
         logo: assets/img/clients/creative-market.jpg
-    
-team:
+
+  team:
     title: "OUR AMAZING TEAM"
     text: "Lorem ipsum dolor sit amet consectetur."
     subtext: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aut eaque, laboriosam veritatis, quos non quis ad perspiciatis, totam corporis ea, alias ut unde. **Markdown** supported.
@@ -116,17 +127,27 @@ team:
             icon: fab fa-facebook-f
           - url: https://linkedin.com
             icon: fab fa-linkedin-in
-          
-contact:
+
+  contact:
     title: "Contact Us"
     text: "Lorem ipsum or call 123456789"
     section: contact
-    
-footer:
+    name: "Name*"
+    name-validation: "Please enter your name."
+    email: "Email*"
+    email-validation: "Please enter your email address."
+    phone: "Phone Number"
+    phone-validation: "Please enter your phone number."
+    message: "Message*"
+    message-validation: "Please enter a message."
+    subject: "Contact Form Submission"
+    submit: "Send Message"
+
+  footer:
     legal: "Privacy Policy"
     social:
       - url: https://twitter.com
-        icon: "fab fa-twitter"  
+        icon: "fab fa-twitter"
       - url: https://facebook.com
         icon: "fab fa-facebook-f"
       - url: https://linkedin.com
@@ -135,6 +156,165 @@ footer:
         icon: "fab fa-github"
       - url: https://instagram.com
         icon: "fab fa-instagram"
+en-US:
+  <<: *DEFAULT_EN
+en-CA:
+  <<: *DEFAULT_EN
+en-GB:
+  <<: *DEFAULT_EN
+en-AU:
+  <<: *DEFAULT_EN
 
+# Spanish
+# -------
+es: &DEFAULT_ES
+  header:
+    title: ¡Bienvenido a nuestro Estudio!
+    text: Es un placer conocerle
+    button: Ver más
+    buttonlink: "#servicios"
 
-# {{ site.data.sitetext.ex.ex | markdownify | default: example }}
+  services:
+    title: "Servicios"
+    text: "Lorem ipsum"
+    section: servicios
+    list:
+      - title: "Comercio Electrónico"
+        desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+        icon: fas fa-shopping-cart #find more at https://fontawesome.com/icons
+      - title: "Diseño Responsivo"
+        desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima maxime quam architecto quo inventore harum ex magni, dicta impedit."
+        icon: fas fa-laptop
+      - title: "[Markdown](https://en.wikipedia.org/wiki/Markdown)"
+        desc: "Su descripción aquí, soporte completo de **Markdown**"
+        icon: fab fa-markdown
+
+  portfolio:
+    title: "Portafolio"
+    text: "Lorem ipsum dolor sit amet consectetur."
+    section: portafolio
+    closebutton: "Cerrar Proyecto"
+
+  timeline:
+    title: "Cronología"
+    text: "Lorem ipsum timeline"
+    section: cronologia
+    # left is the default
+    #start_align: "left"
+    events:
+      - title: "Nuestro Humilde Comienzo"
+        year: "2009-2011"
+        desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
+        image: assets/img/timeline/1.jpg
+        alt:
+      - title: "Una Agencia nace"
+        year: "March 2011"
+        desc: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt ut voluptatum eius sapiente, totam reiciendis temporibus qui quibusdam, recusandae sit vero unde, sed, incidunt et ea quo dolore laudantium consectetur!"
+        image: assets/img/timeline/2.jpg
+        alt:
+      - title: "La plantilla Jekyll es creada"
+        year: "2019"
+        desc: "Ravi Riley convirtió Agency, una plantilla basada en Bootstrap, en una plantilla de Jekyll. La plantilla Jekyll puede ser instalada commo una gema de Ruby (Ruby gem) o remotamente. Para más información, visite la documentación."
+        image: assets/img/timeline/3.jpg
+        alt: image alt text
+      - title: "Título"
+        year: "2009-2011"
+        desc: "Su descripción aquí, **Markdown** es soportado completamente."
+        image: assets/img/timeline/4.jpg
+        alt:
+        # you can enforce the alignment
+        align: right
+    end: "¡Se parte <br> de Nuestra <br> Historia!"
+
+  about:
+    title: "Sobre nosotros"
+    text: "nuestra historia"
+    section: nosotros
+
+  clients:
+    section: clientes
+    max-height: 100px
+    horizontal-scrolling: "" #"yes/no"
+    list:
+      - title: "envato"
+        url: https://github.com/raviriley/agency-jekyll-theme
+        logo: assets/img/clients/envato.jpg
+      - title: "designmodo"
+        url: https://github.com/raviriley/agency-jekyll-theme
+        logo: assets/img/clients/designmodo.jpg
+      - title: "themeforest"
+        url: https://github.com/raviriley/agency-jekyll-theme
+        logo: assets/img/clients/themeforest.jpg
+      - title: "Creative Market"
+        url: https://github.com/raviriley/agency-jekyll-theme
+        logo: assets/img/clients/creative-market.jpg
+
+  team:
+    title: "NUESTRO INCREÍBLE EQUIPO"
+    text: "Lorem ipsum dolor sit amet consectetur."
+    subtext: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aut eaque, laboriosam veritatis, quos non quis ad perspiciatis, totam corporis ea, alias ut unde. **Markdown** supported.
+    section: equipo
+    people:
+      - name: "Kay Garland"
+        role: "Lead Designer"
+        image: assets/img/team/500x500.jpg
+        social:
+          - url: https://twitter.com
+            icon: fab fa-twitter
+          - url: https://facebook.com
+            icon: fab fa-facebook-f
+          - url: https://linkedin.com
+            icon: fab fa-linkedin-in
+      - name: "Larry Parker"
+        role: "Lead Marketer"
+        image: assets/img/team/2.jpg
+        social:
+          - url: https://twitter.com
+            icon: fab fa-twitter
+          - url: https://facebook.com
+            icon: fab fa-facebook-f
+          - url: https://linkedin.com
+            icon: fab fa-linkedin-in
+      - name: "Diana Perterson"
+        role: "Lead Developer"
+        image: assets/img/team/500x500.jpg
+        social:
+          - url: https://twitter.com
+            icon: fab fa-twitter
+          - url: https://facebook.com
+            icon: fab fa-facebook-f
+          - url: https://linkedin.com
+            icon: fab fa-linkedin-in
+
+  contact:
+    title: "Contáctenos"
+    text: "Lorem ipsum or call 123456789"
+    section: contacto
+    name: "Nombre*"
+    name-validation: "Por favor ingrese su nombre."
+    email: "Correo Electrónico*"
+    email-validation: "Por favor ingrese su correo electrónico."
+    phone: "Número Telefónico*"
+    phone-validation: "Por favor ingrese su número telefónico."
+    message: "Mensaje*"
+    message-validation: "Por favor escriba un mensaje."
+    subject: "Envío del formulario de contacto"
+    submit: "Enviar Mensaje"
+
+  footer:
+    legal: "Política de Privacidad"
+    social:
+      - url: https://twitter.com
+        icon: "fab fa-twitter"
+      - url: https://facebook.com
+        icon: "fab fa-facebook-f"
+      - url: https://linkedin.com
+        icon: "fab fa-linkedin-in"
+      - url: https://github.com/raviriley/agency-jekyll-theme
+        icon: "fab fa-github"
+      - url: https://instagram.com
+        icon: "fab fa-instagram"
+es-ES:
+  <<: *DEFAULT_ES
+es-CO:
+  <<: *DEFAULT_ES

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,15 +1,15 @@
 <!-- About -->
-  <section class="page-section" id="{{ site.data.sitetext.about.section | default: "about" }}">
+  <section class="page-section" id="{{ site.data.sitetext[site.locale].about.section | default: "about" }}">
     <div class="container">
       <div class="row">
         <div class="col-lg-12 text-center">
-          <h2 class="section-heading text-uppercase">{{ site.data.sitetext.about.title | default: "About Us" }}</h2>
-          <h3 class="section-subheading text-muted">{{ site.data.sitetext.about.text | default: "" }}</h3>
+          <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].about.title | default: "About Us" }}</h2>
+          <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].about.text | default: "" }}</h3>
         </div>
       </div>
 	  <div class="row">
 		<div class="col-lg-8 mx-auto text-center">
-		  <div class="large text-muted">{{ site.data.sitetext.about.text | markdownify }}</div>
+		  <div class="large text-muted">{{ site.data.sitetext[site.locale].about.text | markdownify }}</div>
 		</div>
 	  </div>
     </div>

--- a/_includes/clients.html
+++ b/_includes/clients.html
@@ -1,11 +1,11 @@
 <!-- Clients -->
-  <section class="py-5" id="{{ site.data.sitetext.clients.section | default: "clients" }}">
+  <section class="py-5" id="{{ site.data.sitetext[site.locale].clients.section | default: "clients" }}">
     <div class="container">
-      <div class="row" {% if site.data.sitetext.clients.horizontal-scrolling == "yes" %} id="scrolling-clients" {% endif %}>
-	  {% for client in site.data.sitetext.clients.list %}
+      <div class="row" {% if site.data.sitetext[site.locale].clients.horizontal-scrolling == "yes" %} id="scrolling-clients" {% endif %}>
+	  {% for client in site.data.sitetext[site.locale].clients.list %}
         <div class="col-md-3 col-sm-6">
           <a href="{{ client.url }}">
-            <img class="img-fluid d-block mx-auto" src="{{ client.logo }}" alt="{{ client.title }}" style="max-height: {{ site.data.sitetext.clients.max-height | default: "100px" }}">
+            <img class="img-fluid d-block mx-auto" src="{{ client.logo }}" alt="{{ client.title }}" style="max-height: {{ site.data.sitetext[site.locale].clients.max-height | default: "100px" }}">
           </a>
         </div>
 	  {% endfor %}

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,49 +1,62 @@
 <!-- Contact -->
-  <section class="page-section" id="{{ site.data.sitetext.contact.section | default: "contact" }}">
-    <div class="container">
-      <div class="row">
-        <div class="col-lg-12 text-center">
-          <h2 class="section-heading text-uppercase">{{ site.data.sitetext.contact.title | markdownify | default: Contact Us }}</h2>
-          <h3 class="section-subheading text-muted">{{ site.data.sitetext.contact.text | default: "" }}</h3>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-lg-12">
-          <form id="contactForm" action="https://formspree.io/{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}" novalidate="novalidate" method="POST">
-		  <!--name="sentMessage"-->
-            <div class="row">
-              <div class="col-md-6">
-                <div class="form-group">
-                  <input name="name" class="form-control" id="name" type="text" placeholder="Name*" required="required" data-validation-required-message="Please enter your name.">
-                  <p class="help-block text-danger"></p>
-                </div>
-                <div class="form-group">
-                  <input name="_replyto" class="form-control" id="email" type="email" placeholder="Email*" required="required" data-validation-required-message="Please enter your email address.">
-                  <p class="help-block text-danger"></p>
-                </div>
-                <div class="form-group">
-                  <input name="phone" class="form-control" id="phone" type="tel" placeholder="Phone Number*" required="required" data-validation-required-message="Please enter your phone number.">
-                  <p class="help-block text-danger"></p>
-                </div>
-              </div>
-              <div class="col-md-6">
-                <div class="form-group">
-                  <textarea name="message" class="form-control" id="message" placeholder="Message*" required="required" data-validation-required-message="Please enter a message."></textarea>
-                  <p class="help-block text-danger"></p>
-                </div>
-              </div>
-			  <input type="hidden" name="_subject" id="email-subject" value="Contact Form Submission">
-              <div class="clearfix"></div>
-              <div class="col-lg-12 text-center">
-                <div id="success"></div>
-                <button id="sendMessageButton" class="btn btn-primary btn-xl text-uppercase" type="submit">Send Message</button>
-              </div>
-			  <input type="text" name="_gotcha" style="display:none">
-			  <input type="hidden" name="_next" value="#"/>
-            </div>
-          </form>
-        </div>
+<section class="page-section" id="{{ site.data.sitetext[site.locale].contact.section | default: "contact" }}">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12 text-center">
+        <h2 class="section-heading text-uppercase">
+          {{ site.data.sitetext[site.locale].contact.title | markdownify | default: Contact Us }}</h2>
+        <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].contact.text | default: "" }}</h3>
       </div>
     </div>
-  </section>
+    <div class="row">
+      <div class="col-lg-12">
+        <form id="contactForm"
+          action="https://formspree.io/{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}"
+          novalidate="novalidate" method="POST">
+          <!--name="sentMessage"-->
+          <div class="row">
+            <div class="col-md-6">
+              <div class="form-group">
+                <input name="name" class="form-control" id="name" type="text"
+                  placeholder="{{ site.data.sitetext[site.locale].contact.name | default: "Name*" }}"
+                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.name-validation | default: "Please enter your name." }}">
+                <p class="help-block text-danger"></p>
+              </div>
+              <div class="form-group">
+                <input name="_replyto" class="form-control" id="email" type="email"
+                  placeholder="{{ site.data.sitetext[site.locale].contact.email | default: "Email*" }}"
+                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.email-validation | default: "Please enter your email address." }}">
+                <p class="help-block text-danger"></p>
+              </div>
+              <div class="form-group">
+                <input name="phone" class="form-control" id="phone" type="tel"
+                  placeholder="{{ site.data.sitetext[site.locale].contact.phone | default: "Phone Number*" }}"
+                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.phone-validation | default: "Please enter your phone number." }}">
+                <p class="help-block text-danger"></p>
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="form-group">
+                <textarea name="message" class="form-control" id="message"
+                  placeholder="{{ site.data.sitetext[site.locale].contact.message | default: "Message*" }}"
+                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.message-validation | default: "Please enter a message." }}"></textarea>
+                <p class="help-block text-danger"></p>
+              </div>
+            </div>
+            <input type="hidden" name="_subject" id="email-subject"
+              value="{{ site.data.sitetext[site.locale].contact.subject | default: "Contact Form Submission" }}">
+            <div class="clearfix"></div>
+            <div class="col-lg-12 text-center">
+              <div id="success"></div>
+              <button id="sendMessageButton" class="btn btn-primary btn-xl text-uppercase"
+                type="submit">{{ site.data.sitetext[site.locale].contact.submit | default: "Send Message" }}</button>
+            </div>
+            <input type="text" name="_gotcha" style="display:none">
+            <input type="hidden" name="_next" value="#" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>
 <!-- End Contact -->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
 		<!-- Social Media -->
         <div class="col-md-4">
           <ul class="list-inline social-buttons">
-		  {% for link in site.data.sitetext.footer.social  %}
+		  {% for link in site.data.sitetext[site.locale].footer.social  %}
             <li class="list-inline-item">
 			  {% if link.url %}
               <a href="{{ link.url }}">
@@ -23,7 +23,7 @@
         <div class="col-md-4">
           <ul class="list-inline quicklinks">
             <li class="list-inline-item">
-              <a href="legal">{{ site.data.sitetext.footer.legal | default: "Privacy Policy" }}</a>
+              <a href="legal">{{ site.data.sitetext[site.locale].footer.legal | default: "Privacy Policy" }}</a>
             </li>
           </ul>
         </div>

--- a/_includes/modals.html
+++ b/_includes/modals.html
@@ -19,7 +19,7 @@
 				<p>{{ project.content }}</p>		
                 <button class="btn btn-primary" data-dismiss="modal" type="button">
                   <i class="fas fa-times"></i>
-                  {{ site.data.sitetext.portfolio.closebutton | default: "Close Project" }}</button>
+                  {{ site.data.sitetext[site.locale].portfolio.closebutton | default: "Close Project" }}</button>
               </div>
             </div>
           </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -14,7 +14,7 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav text-uppercase ml-auto">
-		{%- for link in site.data.navigation.nav -%}
+		{%- for link in site.data.navigation[site.locale].nav -%}
 		  <li class="nav-item">
 		  {%- if link.url -%}
 		    <a class="nav-link js-scroll-trigger" href="{{ link.url }}">{{ link.title }}</a>

--- a/_includes/navheader.html
+++ b/_includes/navheader.html
@@ -14,7 +14,7 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav text-uppercase ml-auto">
-		  {%- for link in site.data.navigation.nav -%}
+		  {%- for link in site.data.navigation[site.locale].nav -%}
 		  <li class="nav-item">
 		  {%- if link.url -%}
 		    <a class="nav-link js-scroll-trigger" href="{{ link.url }}">{{ link.title }}</a>
@@ -36,14 +36,14 @@
   <header class="masthead">
     <div class="container">
       <div class="intro-text">
-	  {%- if site.data.sitetext.header.title -%}
-        <div class="intro-lead-in">{{ site.data.sitetext.header.title | markdownify }}</div>
+	  {%- if site.data.sitetext[site.locale].header.title -%}
+        <div class="intro-lead-in">{{ site.data.sitetext[site.locale].header.title | markdownify }}</div>
 	  {%- endif -%}
-	  {%- if site.data.sitetext.header.text -%}
-        <div class="intro-heading text-uppercase">{{ site.data.sitetext.header.text | markdownify }}</div>
+	  {%- if site.data.sitetext[site.locale].header.text -%}
+        <div class="intro-heading text-uppercase">{{ site.data.sitetext[site.locale].header.text | markdownify }}</div>
 	  {%- endif -%}
-	  {%- if site.data.sitetext.header.button -%}
-        <a class="btn btn-primary btn-xl text-uppercase js-scroll-trigger" href="{{ site.data.sitetext.header.buttonlink }}">{{ site.data.sitetext.header.button }}</a>
+	  {%- if site.data.sitetext[site.locale].header.button -%}
+        <a class="btn btn-primary btn-xl text-uppercase js-scroll-trigger" href="{{ site.data.sitetext[site.locale].header.buttonlink }}">{{ site.data.sitetext[site.locale].header.button }}</a>
 	  {%- endif -%}
       </div>
     </div>

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -1,10 +1,10 @@
 <!-- Portfolio Grid -->
-<section class="bg-light page-section" id="{{ site.data.sitetext.portfolio.section | default: "portfolio" }}">
+<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].portfolio.section | default: "portfolio" }}">
   <div class="container">
     <div class="row">
       <div class="col-lg-12 text-center">
-        <h2 class="section-heading text-uppercase">{{ site.data.sitetext.portfolio.title | markdownify | default: "Portfolio" }}</h2>
-        <h3 class="section-subheading text-muted">{{ site.data.sitetext.portfolio.text | markdownify }}</h3>
+        <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].portfolio.title | markdownify | default: "Portfolio" }}</h2>
+        <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].portfolio.text | markdownify }}</h3>
       </div>
     </div>
     <div class="row">

--- a/_includes/services.html
+++ b/_includes/services.html
@@ -1,18 +1,18 @@
 <!-- Services -->
-  <section class="page-section" id="{{ site.data.sitetext.services.section | default: "services" }}">
+  <section class="page-section" id="{{ site.data.sitetext[site.locale].services.section | default: "services" }}">
     <div class="container">
 	
       <div class="row">
         <div class="col-lg-12 text-center">
-          <h2 class="section-heading text-uppercase">{{ site.data.sitetext.services.title | default: "Services" }}</h2>
-          {% if site.data.sitetext.services.text %}
-		  <h3 class="section-subheading text-muted">{{ site.data.sitetext.services.text }}</h3>
+          <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].services.title | default: "Services" }}</h2>
+          {% if site.data.sitetext[site.locale].services.text %}
+		  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].services.text }}</h3>
 		  {% endif %}
         </div>
       </div>
 	  
       <div class="row text-center">
-	  {% for service in site.data.sitetext.services.list %}
+	  {% for service in site.data.sitetext[site.locale].services.list %}
         <div class="col-md-4">
           <span class="fa-stack fa-4x">
             <i class="fas fa-circle fa-stack-2x text-primary"></i>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -1,14 +1,14 @@
 <!-- Team -->
-<section class="bg-light page-section" id="{{ site.data.sitetext.team.section | default: "team" }}">
+<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].team.section | default: "team" }}">
 <div class="container">
   <div class="row">
 	<div class="col-lg-12 text-center">
-	  <h2 class="section-heading text-uppercase">{{ site.data.sitetext.team.title }}</h2>
-	  <h3 class="section-subheading text-muted">{{ site.data.sitetext.team.text }}</h3>
+	  <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].team.title }}</h2>
+	  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
 	</div>
   </div>
   <div class="row">
-  {% for person in site.data.sitetext.team.people %}
+  {% for person in site.data.sitetext[site.locale].team.people %}
 	<div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
@@ -29,7 +29,7 @@
   </div>
   <div class="row">
 	<div class="col-lg-8 mx-auto text-center">
-	  <div class="large text-muted">{{ site.data.sitetext.team.subtext | markdownify }}</div>
+	  <div class="large text-muted">{{ site.data.sitetext[site.locale].team.subtext | markdownify }}</div>
 	</div>
   </div>
 </div>

--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -1,17 +1,17 @@
 <!-- About -->
-  <section class="page-section" id="{{ site.data.sitetext.timeline.section | default: "about" }}">
+  <section class="page-section" id="{{ site.data.sitetext[site.locale].timeline.section | default: "about" }}">
     <div class="container">
       <div class="row">
         <div class="col-lg-12 text-center">
-          <h2 class="section-heading text-uppercase">{{ site.data.sitetext.timeline.title | markdownify | default: "About" }}</h2>
-          <h3 class="section-subheading text-muted">{{ site.data.sitetext.timeline.text | default: "timeline"}}</h3>
+          <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].timeline.title | markdownify | default: "About" }}</h2>
+          <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].timeline.text | default: "timeline"}}</h3>
         </div>
       </div>
       <div class="row">
         <div class="col-lg-12">
           <ul class="timeline">
-      {%- assign align = site.data.sitetext.timeline.start_align -%}
-      {%- for event in site.data.sitetext.timeline.events -%}
+      {%- assign align = site.data.sitetext[site.locale].timeline.start_align -%}
+      {%- for event in site.data.sitetext[site.locale].timeline.events -%}
             {%- if align == "right" -%}
               {%- if event.align and event.align == "left" -%}
                 {%- assign align = "right" -%}
@@ -44,10 +44,10 @@
             </li>
 		  {% endfor %}	
             
-		  {% if site.data.sitetext.timeline.end %}	
+		  {% if site.data.sitetext[site.locale].timeline.end %}	
 			<li class="timeline-inverted">
               <div class="timeline-image">
-                <h4>{{ site.data.sitetext.timeline.end }}</h4>
+                <h4>{{ site.data.sitetext[site.locale].timeline.end }}</h4>
               </div>
             </li>
 		  {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.locale | slice: 0,2 | default: "en" }}">
 
   {% include head.html %}
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

This PR adds SPANISH (Español) Language Support to the theme.

## Context

This work addresses this [**Feature Request**](https://github.com/raviriley/agency-jekyll-theme/issues/2)

## Changes

- _config.yml include variable `locale` -> `locale: "en-US" # See available languages in _data/sitetext.yml`
- _data/sitetext.yml define variables for English `US, CA, GB, AU` and Spanish (Español) `ES, CO`
- _data/sitetext.yml translate content to Spanish
- _data/navigation.yml define variables for English `US, CA, GB, AU` and Spanish (Español) `ES, CO`
- _data/navigation.yml translate content to Spanish
-  _includes/about.html, _includes/clients.html, _includes/contact.html, _includes/footer.html, _includes/modals.html, _includes/portfolio_grid.html, _includes/services.html, _includes/team.html, _includes/timeline.html change variable from `site.data.sitetext.` to `site.data.sitetext[site.locale].`
- _includes/nav.html and _includes/navheader.html change variable from `site.data.navigation.nav` to `site.data.navigation[site.locale].nav`
- _layouts/default.html change `<html>` to `<html lang="{{ site.locale | slice: 0,2 | default: "en" }}">`
