### PR TITLE
delete extraneous </li>

### DIFF
--- a/_includes/navheader.html
+++ b/_includes/navheader.html
@@ -25,7 +25,6 @@
 		  {%- endif -%}
           </li>
 		  {% endfor %}
-          </li>
         </ul>
       </div>
     </div>

--- a/_includes/navheader.html
+++ b/_includes/navheader.html
@@ -1,7 +1,7 @@
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
     <div class="container">
-	  <a class="navbar-brand js-scroll-trigger" href="#page-top">
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">
           {%- if site.logo -%}
             <img height="{{ site.logo.height | default: 52 }}" src="{{ site.logo.path }}"/>
           {%- else -%}
@@ -14,17 +14,17 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav text-uppercase ml-auto">
-		  {%- for link in site.data.navigation[site.locale].nav -%}
-		  <li class="nav-item">
-		  {%- if link.url -%}
-		    <a class="nav-link js-scroll-trigger" href="{{ link.url }}">{{ link.title }}</a>
-		  {%- else if link.section -%}
-		    <a class="nav-link js-scroll-trigger" href="#{{ link.section }}">{{ link.title }}</a>
-		  {%- else -%}
-		    <a class="nav-link js-scroll-trigger" href="#">{{ link.title }}</a>
-		  {%- endif -%}
+        {%- for link in site.data.navigation[site.locale].nav -%}
+          <li class="nav-item">
+            {%- if link.url -%}
+              <a class="nav-link js-scroll-trigger" href="{{ link.url }}">{{ link.title }}</a>
+            {%- else if link.section -%}
+              <a class="nav-link js-scroll-trigger" href="#{{ link.section }}">{{ link.title }}</a>
+            {%- else -%}
+              <a class="nav-link js-scroll-trigger" href="#">{{ link.title }}</a>
+            {%- endif -%}
           </li>
-		  {% endfor %}
+        {% endfor %}
         </ul>
       </div>
     </div>
@@ -35,15 +35,15 @@
   <header class="masthead">
     <div class="container">
       <div class="intro-text">
-	  {%- if site.data.sitetext[site.locale].header.title -%}
+      {%- if site.data.sitetext[site.locale].header.title -%}
         <div class="intro-lead-in">{{ site.data.sitetext[site.locale].header.title | markdownify }}</div>
-	  {%- endif -%}
-	  {%- if site.data.sitetext[site.locale].header.text -%}
+      {%- endif -%}
+      {%- if site.data.sitetext[site.locale].header.text -%}
         <div class="intro-heading text-uppercase">{{ site.data.sitetext[site.locale].header.text | markdownify }}</div>
-	  {%- endif -%}
-	  {%- if site.data.sitetext[site.locale].header.button -%}
+      {%- endif -%}
+      {%- if site.data.sitetext[site.locale].header.button -%}
         <a class="btn btn-primary btn-xl text-uppercase js-scroll-trigger" href="{{ site.data.sitetext[site.locale].header.buttonlink }}">{{ site.data.sitetext[site.locale].header.button }}</a>
-	  {%- endif -%}
+      {%- endif -%}
       </div>
     </div>
   </header>


### PR DESCRIPTION
This is a bug fix.

## Summary

`navheader.html` had an extra closing `</li>` outside of the loop for the navbar.

## Testing

Copied the `navheader.html` into my project's `_includes/` directory and removed the line. Verified that this removed the literal `</li>` from my page's output.