### PR TITLE
fix default whitespace characters in contact form

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -40,8 +40,7 @@
               <div class="form-group">
                 <textarea name="message" class="form-control" id="message"
                   placeholder="{{ site.data.sitetext[site.locale].contact.message | default: "Message*" }}"
-                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.message-validation | default: "Please enter a message." }}">
-                </textarea>
+                  required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.message-validation | default: "Please enter a message." }}"></textarea>
                 <p class="help-block text-danger"></p>
               </div>
             </div>
@@ -102,8 +101,7 @@
               <div class="form-group">
                 <textarea name="message" class="form-control" id="message"
                   placeholder="{{ site.data.sitetext.contact.message | default: "Message*" }}"
-                  required="required" data-validation-required-message="{{ site.data.sitetext.contact.message-validation | default: "Please enter a message." }}">
-                </textarea>
+                  required="required" data-validation-required-message="{{ site.data.sitetext.contact.message-validation | default: "Please enter a message." }}"></textarea>
                 <p class="help-block text-danger"></p>
               </div>
             </div>


### PR DESCRIPTION
<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
This fix removes the default whitespace characters from the message area of the contact form.
## Context
Before this fix, the message box would have whitespace characters when the page loads which could result in them being included in the message sent when used by someone.
<!--
  Is this related to any GitHub issue(s)?
-->
This fix addresses the issue I created [here](https://github.com/raviriley/agency-jekyll-theme/issues/60).