### PR TITLE
Centering team members dynamically

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-  	<div class="col-sm-4">
+	<div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +46,7 @@
 	  </div>
 	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-    		<div class="col-sm-4">
+		<div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -8,7 +8,6 @@
 	  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
 	</div>
   </div>
-   <div class="container text-center">
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
   <div class="col-sm-4">
@@ -28,7 +27,6 @@
 	  </div>
 	</div>
   {% endfor %}
-  </div>
   </div>
   <div class="row">
 	<div class="col-lg-8 mx-auto text-center">

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,13 @@
   </div>
   <div class="row">
   {% for person in site.data.sitetext[site.locale].team.people %}
-	<div class="col-sm-4">
+    {% if site.data.sitetext[site.locale].team.people.size == 1 %}
+  	  <div class="col-sm-12">
+    {% elsif site.data.sitetext[site.locale].team.people.size == 2 %}
+  	  <div class="col-sm-6">
+    {% else %}
+      <div class="col-sm-4">
+    {% endif %}
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +52,13 @@
 	  </div>
 	  <div class="row">
 	  {% for person in site.data.sitetext.team.people %}
-		<div class="col-sm-4">
+		  {% if site.data.sitetext.team.people.size == 1 %}
+        <div class="col-sm-12">
+      {% elsif site.data.sitetext.team.people.size == 2 %}
+        <div class="col-sm-6">
+      {% else %}
+        <div class="col-sm-4">
+      {% endif %}
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-  <div class="col-sm-4">
+  	<div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +46,7 @@
 	  </div>
 	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-    <div class="col-sm-4">
+    		<div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -8,15 +8,10 @@
 	  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
 	</div>
   </div>
-  <div class="row">
+   <div class="container text-center">
+  <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-    {% if site.data.sitetext[site.locale].team.people.size == 1 %}
-  	  <div class="col-sm-12">
-    {% elsif site.data.sitetext[site.locale].team.people.size == 2 %}
-  	  <div class="col-sm-6">
-    {% else %}
-      <div class="col-sm-4">
-    {% endif %}
+  <div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -34,6 +29,7 @@
 	</div>
   {% endfor %}
   </div>
+  </div>
   <div class="row">
 	<div class="col-lg-8 mx-auto text-center">
 	  <div class="large text-muted">{{ site.data.sitetext[site.locale].team.subtext | markdownify }}</div>
@@ -50,15 +46,9 @@
 		  <h3 class="section-subheading text-muted">{{ site.data.sitetext.team.text }}</h3>
 		</div>
 	  </div>
-	  <div class="row">
+	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-		  {% if site.data.sitetext.team.people.size == 1 %}
-        <div class="col-sm-12">
-      {% elsif site.data.sitetext.team.people.size == 2 %}
-        <div class="col-sm-6">
-      {% else %}
-        <div class="col-sm-4">
-      {% endif %}
+    <div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary
Centering all team members dynamically irrespective of the number of members.

When team member is 1 they are centered.

For a team of two, each block take up half of the width of the screen.

For a team of four, one row of three that works like it is now, and a second row where the 4th member is centered.

## Context
  Is this related to any GitHub issue(s)?
This is related to [Github issue #51](https://github.com/raviriley/agency-jekyll-theme/issues/51)
