### PR TITLE
Resolve bug: Issue #63 - Display translated text and Working hover effect for locale: "de" and "de-DE"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -75,3 +75,5 @@ de: &DEFAULT_DE
       section: Kontakt
     - title: "Quellcode des Themas"
       url: https://github.com/raviriley/agency-jekyll-theme/
+de-DE:
+  <<: *DEFAULT_DE

--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -471,3 +471,5 @@ de: &DEFAULT_DE
         icon: "fab fa-github"
       - url: https://instagram.com
         icon: "fab fa-instagram"
+de-DE:
+  <<: *DEFAULT_DE

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -1,6 +1,6 @@
 <!-- Portfolio Grid -->
 {% if site.locale and site.locale != "" and site.locale != nil %}
-<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].portfolio.section | default: "portfolio" }}">
+<section class="bg-light page-section" id="{{ site.data.sitetext.portfolio.section | default: "portfolio" }}">
   <div class="container">
     <div class="row">
       <div class="col-lg-12 text-center">

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-  	<div class="col-sm-4">
+	<div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +46,7 @@
 	  </div>
 	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-    		<div class="col-sm-4">
+		<div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -8,7 +8,6 @@
 	  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
 	</div>
   </div>
-   <div class="container text-center">
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
   <div class="col-sm-4">
@@ -28,7 +27,6 @@
 	  </div>
 	</div>
   {% endfor %}
-  </div>
   </div>
   <div class="row">
 	<div class="col-lg-8 mx-auto text-center">

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,13 @@
   </div>
   <div class="row">
   {% for person in site.data.sitetext[site.locale].team.people %}
-	<div class="col-sm-4">
+    {% if site.data.sitetext[site.locale].team.people.size == 1 %}
+  	  <div class="col-sm-12">
+    {% elsif site.data.sitetext[site.locale].team.people.size == 2 %}
+  	  <div class="col-sm-6">
+    {% else %}
+      <div class="col-sm-4">
+    {% endif %}
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +52,13 @@
 	  </div>
 	  <div class="row">
 	  {% for person in site.data.sitetext.team.people %}
-		<div class="col-sm-4">
+		  {% if site.data.sitetext.team.people.size == 1 %}
+        <div class="col-sm-12">
+      {% elsif site.data.sitetext.team.people.size == 2 %}
+        <div class="col-sm-6">
+      {% else %}
+        <div class="col-sm-4">
+      {% endif %}
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-  <div class="col-sm-4">
+  	<div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +46,7 @@
 	  </div>
 	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-    <div class="col-sm-4">
+    		<div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -8,15 +8,10 @@
 	  <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
 	</div>
   </div>
-  <div class="row">
+   <div class="container text-center">
+  <div class="row d-flex justify-content-center">
   {% for person in site.data.sitetext[site.locale].team.people %}
-    {% if site.data.sitetext[site.locale].team.people.size == 1 %}
-  	  <div class="col-sm-12">
-    {% elsif site.data.sitetext[site.locale].team.people.size == 2 %}
-  	  <div class="col-sm-6">
-    {% else %}
-      <div class="col-sm-4">
-    {% endif %}
+  <div class="col-sm-4">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -34,6 +29,7 @@
 	</div>
   {% endfor %}
   </div>
+  </div>
   <div class="row">
 	<div class="col-lg-8 mx-auto text-center">
 	  <div class="large text-muted">{{ site.data.sitetext[site.locale].team.subtext | markdownify }}</div>
@@ -50,15 +46,9 @@
 		  <h3 class="section-subheading text-muted">{{ site.data.sitetext.team.text }}</h3>
 		</div>
 	  </div>
-	  <div class="row">
+	  <div class="row d-flex justify-content-center">
 	  {% for person in site.data.sitetext.team.people %}
-		  {% if site.data.sitetext.team.people.size == 1 %}
-        <div class="col-sm-12">
-      {% elsif site.data.sitetext.team.people.size == 2 %}
-        <div class="col-sm-6">
-      {% else %}
-        <div class="col-sm-4">
-      {% endif %}
+    <div class="col-sm-4">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>


### PR DESCRIPTION
## This is a bug fix

## Summary
This PR is resolving the issues related translation and hover effects when locale entry in _config.yml  is set to "de" or "de-DE".
I the bug can be separated into 3 parts.
 - [x] 1. Show translated German Navbar whether you set the locale to "de" or "de-DE" on config.yml.
 - [x] 2. Show translated content whether you set the locale to "de" or "de-DE" on config.yml.
 - [x] 3. The portfolio hover effect stops working and the plus icon gets misplaced.

The hover effect solution works for Spanish language as well.

## Context
This is related to GitHub issue: Switching default locale to German  issue #63
