### PR TITLE
Display translated text and Working hover effect for locale: "de" and "de-DE"(Resolve bug: Issue #63)

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -75,3 +75,5 @@ de: &DEFAULT_DE
       section: Kontakt
     - title: "Quellcode des Themas"
       url: https://github.com/raviriley/agency-jekyll-theme/
+de-DE:
+  <<: *DEFAULT_DE

--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -471,3 +471,5 @@ de: &DEFAULT_DE
         icon: "fab fa-github"
       - url: https://instagram.com
         icon: "fab fa-instagram"
+de-DE:
+  <<: *DEFAULT_DE

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -1,6 +1,6 @@
 <!-- Portfolio Grid -->
 {% if site.locale and site.locale != "" and site.locale != nil %}
-<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].portfolio.section | default: "portfolio" }}">
+<section class="bg-light page-section" id="{{ site.data.sitetext.portfolio.section | default: "portfolio" }}">
   <div class="container">
     <div class="row">
       <div class="col-lg-12 text-center">


### PR DESCRIPTION
This is a bug fix

## Summary
This PR is resolving the issues related translation and hover effects when locale entry in _config.yml  is set to "de" or "de-DE".
I the bug can be separated into 3 parts.
 - [x] 1. Show translated German Navbar whether you set the locale to "de" or "de-DE" on config.yml.
 - [x] 2. Show translated content whether you set the locale to "de" or "de-DE" on config.yml.
 - [x] 3. The portfolio hover effect stops working and the plus icon gets misplaced.

The hover effect solution works for Spanish language as well.

## Context
This is related to GitHub issue: Switching default locale to German  issue #63
