### PR TITLE
Add the ability to override fonts (resolves issue #65 )

### DIFF
--- a/_data/style.yml
+++ b/_data/style.yml
@@ -8,3 +8,12 @@ header-image: "../img/header.png"
 contact-image: "../img/contact.png"
 #Font Awesome icon for portfolio grid when an item is hovered over
 #portfolio-icon: fas fa-expand-arrows-alt fa-3x #default: fas fa-plus fa-3x
+
+# Add custom fonts
+fonts_urls:
+    - "https://fonts.googleapis.com/css?family=Montserrat:400,700"
+    - "https://fonts.googleapis.com/css?family=Kaushan+Script"
+    - "https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic"
+    - "https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700"
+
+

--- a/_data/style.yml
+++ b/_data/style.yml
@@ -16,4 +16,13 @@ fonts_urls:
     - "https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic"
     - "https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700"
 
-
+# Set custom fonts
+fonts:
+  - name: "Montserrat"
+    for: "heading"
+  - name: "Kaushan Script"
+    for: "script"
+  - name: "Droid Serif"
+    for: "serif"
+  - name: "Roboto Slab"
+    for: "body"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,11 +27,9 @@
 
   <!-- Custom fonts for this template -->
   <link href="assets/css/all.min.css" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-  <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
-  <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-  <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
-
+  {% for font_url in site.data.style.fonts_urls %}
+  <link href="{{font_url}}" rel="stylesheet" type="text/css">
+  {% endfor %}
   <!-- Custom styles for this theme -->
   <!--<link href="assets/css/agency.min.css" rel="stylesheet">-->
   <link href="assets/css/agency.css" rel="stylesheet" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,9 +27,17 @@
 
   <!-- Custom fonts for this template -->
   <link href="assets/css/all.min.css" rel="stylesheet" type="text/css">
-  {% for font_url in site.data.style.fonts_urls %}
-  <link href="{{font_url}}" rel="stylesheet" type="text/css">
-  {% endfor %}
+  {% if site.data.style.fonts_urls %}
+    {% for font_url in site.data.style.fonts_urls %}
+      <link href="{{font_url}}" rel="stylesheet" type="text/css">
+    {% endfor %}
+  {% else %}
+    <link href="assets/css/all.min.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
+  {% endif %}
   <!-- Custom styles for this theme -->
   <!--<link href="assets/css/agency.min.css" rel="stylesheet">-->
   <link href="assets/css/agency.css" rel="stylesheet" />

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -5,6 +5,15 @@
 @import "base/variables.scss";
 @import "base/mixins.scss";
 
+// Custom Fonts
+{% for font in site.data.style.fonts %}
+@mixin {{font.for}}-font {
+  font-family: "{{ font.name }}", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+{% endfor %}
+
 // Custom colors
 $primary: {{ site.data.style.highlight | default: "#fed136" }} !default;
 $white: {{ site.data.style.white | default: "#fff" }} !default;

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -6,13 +6,15 @@
 @import "base/mixins.scss";
 
 // Custom Fonts
-{% for font in site.data.style.fonts %}
-@mixin {{font.for}}-font {
-  font-family: "{{ font.name }}", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
-{% endfor %}
+{% if site.data.style.fonts %}
+  {% for font in site.data.style.fonts %}
+    @mixin {{font.for}}-font {
+      font-family: "{{ font.name }}", -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    }
+  {% endfor %}
+{% endif %}
 
 // Custom colors
 $primary: {{ site.data.style.highlight | default: "#fed136" }} !default;


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

With this new feature, users can add new fonts, or update current fonts by just editing the style.yml file.

How it works
- Use the "fonts_urls" to add any font to the website.
- Use the "fonts" to match a font mixin with the corresponding font name.

## Context

This is related to GitHub issue #65 
