### PR TITLE
Stopping basic spam bots from filling contact form

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -23,6 +23,11 @@
                   required="required" data-validation-required-message="{{ site.data.sitetext[site.locale].contact.name-validation | default: "Please enter your name." }}">
                 <p class="help-block text-danger"></p>
               </div>
+              <div class="form-group d-none">
+                <input name="username" class="form-control" id="username" type="text" tabindex="-1" autocomplete="off"
+                  placeholder="{{ site.data.sitetext[site.locale].contact.username | default: "Username*" }}">
+                <p class="help-block text-danger"></p>
+              </div>
               <div class="form-group">
                 <input name="_replyto" class="form-control" id="email" type="email"
                   placeholder="{{ site.data.sitetext[site.locale].contact.email | default: "Email*" }}"
@@ -82,6 +87,11 @@
                 <input name="name" class="form-control" id="name" type="text"
                   placeholder="{{ site.data.sitetext.contact.name | default: "Name*" }}"
                   required="required" data-validation-required-message="{{ site.data.sitetext.contact.name-validation | default: "Please enter your name." }}">
+                <p class="help-block text-danger"></p>
+              </div>
+              <div class="form-group d-none">
+                <input name="username" class="form-control" id="username" type="text" tabindex="-1" autocomplete="off"
+                  placeholder="{{ site.data.sitetext.contact.username | default: "Username*" }}">
                 <p class="help-block text-danger"></p>
               </div>
               <div class="form-group">

--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -12,6 +12,7 @@ $(function() {
       // get values from FORM
 	  var url = "https://formspree.io/" + "{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}";
       var name = $("input#name").val();
+      var username = $("input#username").val();
       var email = $("input#email").val();
       var phone = $("input#phone").val();
       var message = $("textarea#message").val();
@@ -22,48 +23,50 @@ $(function() {
       }
       $this = $("#sendMessageButton");
       $this.prop("disabled", true); // Disable submit button until AJAX call is complete to prevent duplicate messages
-      $.ajax({
-        url: url,
-        type: "POST",
-	dataType: "json",
-        data: {
-          name: name,
-          phone: phone,
-          email: email,
-          message: message
-        },
-        cache: false,
+      if(username === ''){ // Disable's form submit if hidden input(username) has been filled
+        $.ajax({
+          url: url,
+          type: "POST",
+          dataType: "json",
+          data: {
+            name: name,
+            phone: phone,
+            email: email,
+            message: message
+          },
+          cache: false,
 
-		success: function() {
-          // Success message
-          $('#success').html("<div class='alert alert-success'>");
-          $('#success > .alert-success').html("<button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;")
-            .append("</button>");
-          $('#success > .alert-success')
-            .append("<strong>Your message has been sent. </strong>");
-          $('#success > .alert-success')
-            .append('</div>');
-          //clear all fields
-          $('#contactForm').trigger("reset");
-        },
+    	  success: function() {
+            // Success message
+            $('#success').html("<div class='alert alert-success'>");
+            $('#success > .alert-success').html("<button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;")
+              .append("</button>");
+            $('#success > .alert-success')
+              .append("<strong>Your message has been sent. </strong>");
+            $('#success > .alert-success')
+              .append('</div>');
+              //clear all fields
+            $('#contactForm').trigger("reset");
+          },
 
-        error: function() {
-          // Fail message
-          $('#success').html("<div class='alert alert-danger'>");
-          $('#success > .alert-danger').html("<button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;")
-            .append("</button>");
-          $('#success > .alert-danger').append($("<strong>").text("Sorry " + firstName + ", it seems that my mail server is not responding. Please try again later!"));
-          $('#success > .alert-danger').append('</div>');
-          //clear all fields
-          $('#contactForm').trigger("reset");
-        },
+          error: function() {
+            // Fail message
+            $('#success').html("<div class='alert alert-danger'>");
+            $('#success > .alert-danger').html("<button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;")
+              .append("</button>");
+            $('#success > .alert-danger').append($("<strong>").text("Sorry " + firstName + ", it seems that my mail server is not responding. Please try again later!"));
+            $('#success > .alert-danger').append('</div>');
+            //clear all fields
+            $('#contactForm').trigger("reset");
+          },
 
-        complete: function() {
-          setTimeout(function() {
-            $this.prop("disabled", false); // Re-enable submit button when AJAX call is complete
-          }, 1000);
-        }
-      });
+          complete: function() {
+            setTimeout(function() {
+              $this.prop("disabled", false); // Re-enable submit button when AJAX call is complete
+            }, 1000);
+          }
+        });
+      }
     },
     filter: function() {
       return $(this).is(":visible");


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

With this new feature, a hidden form field stops spambots from filling and submitting your contact form without using third-party services.

This will not stop human spammers and sophisticated spam bots.

## Context

To stop spammers, many sites use  Google reCAPTCHA and other similar services. These services use a private key that requires a backend(server or serverless function). This solution is for static websites that don't have a backend solution.


This is related to Github Issue #19
