### PR TITLE
Fix getting the anchor from the translation

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -1,6 +1,6 @@
 <!-- Portfolio Grid -->
 {% if site.locale and site.locale != "" and site.locale != nil %}
-<section class="bg-light page-section" id="{{ site.data.sitetext.portfolio.section | default: "portfolio" }}">
+<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].portfolio.section | default: "portfolio" }}">
   <div class="container">
     <div class="row">
       <div class="col-lg-12 text-center">


### PR DESCRIPTION
Add the locale to the variable.

This is a bug fix.

## Summary

The portfolio anchor is always `portfolio` although it should have been `Portfolio` according to default `sitetext.yml`. It appears that the variable was missing the locale part. Thus, the template always used the fallback.

## Context

There is no separate issue report.
