### PR TITLE
(navigation.yml) Add all countries for English, Spanish, and Deutsch

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,7 +7,7 @@
 # How to use:
 # {{ site.data.navigation[site.locale].nav.<var_name> | default: 'text' }}
 
-# English (default)
+# English [default] (https://localizely.com/language-code/en/)
 # -----------------
 en: &DEFAULT_EN
   nav:
@@ -25,16 +25,215 @@ en: &DEFAULT_EN
       section: contact
     - title: "Theme Source"
       url: https://github.com/raviriley/agency-jekyll-theme/
-en-US:
+
+en-001: #English (World)
   <<: *DEFAULT_EN
-en-CA:
+en-150: #English (Europe)
   <<: *DEFAULT_EN
-en-GB:
+en-AG: #English (Antigua and Barbuda)
   <<: *DEFAULT_EN
-en-AU:
+en-AI: #English (Anguilla)
+  <<: *DEFAULT_EN
+en-AS: #English (American Samoa)
+  <<: *DEFAULT_EN
+en-AT: #English (Austria)
+  <<: *DEFAULT_EN
+en-AU: #English (Australia)
+  <<: *DEFAULT_EN
+en-BB: #English (Barbados)
+  <<: *DEFAULT_EN
+en-BE: #English (Belgium)
+  <<: *DEFAULT_EN
+en-BI: #English (Burundi)
+  <<: *DEFAULT_EN
+en-BM: #English (Bermuda)
+  <<: *DEFAULT_EN
+en-BS: #English (Bahamas)
+  <<: *DEFAULT_EN
+en-BW: #English (Botswana)
+  <<: *DEFAULT_EN
+en-BZ: #English (Belize)
+  <<: *DEFAULT_EN
+en-CA: #English (Canada)
+  <<: *DEFAULT_EN
+en-CC: #English (Cocos (Keeling) Islands)
+  <<: *DEFAULT_EN
+en-CH: #English (Switzerland)
+  <<: *DEFAULT_EN
+en-CK: #English (Cook Islands)
+  <<: *DEFAULT_EN
+en-CM: #English (Cameroon)
+  <<: *DEFAULT_EN
+en-CX: #English (Christmas Island)
+  <<: *DEFAULT_EN
+en-CY: #English (Cyprus)
+  <<: *DEFAULT_EN
+en-DE: #English (Germany)
+  <<: *DEFAULT_EN
+en-DK: #English (Denmark)
+  <<: *DEFAULT_EN
+en-DM: #English (Dominica)
+  <<: *DEFAULT_EN
+en-ER: #English (Eritrea)
+  <<: *DEFAULT_EN
+en-FI: #English (Finland)
+  <<: *DEFAULT_EN
+en-FJ: #English (Fiji)
+  <<: *DEFAULT_EN
+en-FK: #English (Falkland Islands)
+  <<: *DEFAULT_EN
+en-FM: #English (Micronesia)
+  <<: *DEFAULT_EN
+en-GB: #English (United Kingdom)
+  <<: *DEFAULT_EN
+en-GD: #English (Grenada)
+  <<: *DEFAULT_EN
+en-GG: #English (Guernsey)
+  <<: *DEFAULT_EN
+en-GH: #English (Ghana)
+  <<: *DEFAULT_EN
+en-GI: #English (Gibraltar)
+  <<: *DEFAULT_EN
+en-GM: #English (Gambia)
+  <<: *DEFAULT_EN
+en-GU: #English (Guam)
+  <<: *DEFAULT_EN
+en-GY: #English (Guyana)
+  <<: *DEFAULT_EN
+en-HK: #English (Hong Kong)
+  <<: *DEFAULT_EN
+en-IE: #English (Ireland)
+  <<: *DEFAULT_EN
+en-IL: #English (Israel)
+  <<: *DEFAULT_EN
+en-IM: #English (Isle of Man)
+  <<: *DEFAULT_EN
+en-IN: #English (India)
+  <<: *DEFAULT_EN
+en-IO: #English (British Indian Ocean Territory)
+  <<: *DEFAULT_EN
+en-JE: #English (Jersey)
+  <<: *DEFAULT_EN
+en-JM: #English (Jamaica)
+  <<: *DEFAULT_EN
+en-KE: #English (Kenya)
+  <<: *DEFAULT_EN
+en-KI: #English (Kiribati)
+  <<: *DEFAULT_EN
+en-KN: #English (Saint Kitts and Nevis)
+  <<: *DEFAULT_EN
+en-KY: #English (Cayman Islands)
+  <<: *DEFAULT_EN
+en-LC: #English (Saint Lucia)
+  <<: *DEFAULT_EN
+en-LR: #English (Liberia)
+  <<: *DEFAULT_EN
+en-LS: #English (Lesotho)
+  <<: *DEFAULT_EN
+en-MG: #English (Madagascar)
+  <<: *DEFAULT_EN
+en-MH: #English (Marshall Islands)
+  <<: *DEFAULT_EN
+en-MO: #English (Macao)
+  <<: *DEFAULT_EN
+en-MP: #English (Northern Mariana Islands)
+  <<: *DEFAULT_EN
+en-MS: #English (Montserrat)
+  <<: *DEFAULT_EN
+en-MT: #English (Malta)
+  <<: *DEFAULT_EN
+en-MU: #English (Mauritius)
+  <<: *DEFAULT_EN
+en-MW: #English (Malawi)
+  <<: *DEFAULT_EN
+en-MY: #English (Malaysia)
+  <<: *DEFAULT_EN
+en-NA: #English (Namibia)
+  <<: *DEFAULT_EN
+en-NF: #English (Norfolk Island)
+  <<: *DEFAULT_EN
+en-NG: #English (Nigeria)
+  <<: *DEFAULT_EN
+en-NL: #English (Netherlands)
+  <<: *DEFAULT_EN
+en-NR: #English (Nauru)
+  <<: *DEFAULT_EN
+en-NU: #English (Niue)
+  <<: *DEFAULT_EN
+en-NZ: #English (New Zealand)
+  <<: *DEFAULT_EN
+en-PG: #English (Papua New Guinea)
+  <<: *DEFAULT_EN
+en-PH: #English (Philippines)
+  <<: *DEFAULT_EN
+en-PK: #English (Pakistan)
+  <<: *DEFAULT_EN
+en-PN: #English (Pitcairn Islands)
+  <<: *DEFAULT_EN
+en-PR: #English (Puerto Rico)
+  <<: *DEFAULT_EN
+en-PW: #English (Palau)
+  <<: *DEFAULT_EN
+en-RW: #English (Rwanda)
+  <<: *DEFAULT_EN
+en-SB: #English (Solomon Islands)
+  <<: *DEFAULT_EN
+en-SC: #English (Seychelles)
+  <<: *DEFAULT_EN
+en-SD: #English (Sudan)
+  <<: *DEFAULT_EN
+en-SE: #English (Sweden)
+  <<: *DEFAULT_EN
+en-SG: #English (Singapore)
+  <<: *DEFAULT_EN
+en-SH: #English (Saint Helena)
+  <<: *DEFAULT_EN
+en-SI: #English (Slovenia)
+  <<: *DEFAULT_EN
+en-SL: #English (Sierra Leone)
+  <<: *DEFAULT_EN
+en-SS: #English (South Sudan)
+  <<: *DEFAULT_EN
+en-SX: #English (Sint Maarten)
+  <<: *DEFAULT_EN
+en-SZ: #English (Eswatini)
+  <<: *DEFAULT_EN
+en-TC: #English (Turks and Caicos Islands)
+  <<: *DEFAULT_EN
+en-TK: #English (Tokelau)
+  <<: *DEFAULT_EN
+en-TO: #English (Tonga)
+  <<: *DEFAULT_EN
+en-TT: #English (Trinidad and Tobago)
+  <<: *DEFAULT_EN
+en-TV: #English (Tuvalu)
+  <<: *DEFAULT_EN
+en-TZ: #English (Tanzania)
+  <<: *DEFAULT_EN
+en-UG: #English (Uganda)
+  <<: *DEFAULT_EN
+en-UM: #English (United States Minor Outlying Islands)
+  <<: *DEFAULT_EN
+en-US: #English (United States)
+  <<: *DEFAULT_EN
+en-VC: #English (Saint Vincent and the Grenadines)
+  <<: *DEFAULT_EN
+en-VG: #English (British Virgin Islands)
+  <<: *DEFAULT_EN
+en-VI: #English (U.S. Virgin Islands)
+  <<: *DEFAULT_EN
+en-VU: #English (Vanuatu)
+  <<: *DEFAULT_EN
+en-WS: #English (Samoa)
+  <<: *DEFAULT_EN
+en-ZA: #English (South Africa)
+  <<: *DEFAULT_EN
+en-ZM: #English (Zambia)
+  <<: *DEFAULT_EN
+en-ZW: #English (Zimbabwe)
   <<: *DEFAULT_EN
 
-# Spanish
+# Spanish (https://localizely.com/language-code/es/)
 # -------
 es: &DEFAULT_ES
   nav:
@@ -52,12 +251,61 @@ es: &DEFAULT_ES
       section: contacto
     - title: "Fuente de la plantilla"
       url: https://github.com/raviriley/agency-jekyll-theme/
-es-ES:
+
+es-419: #Spanish (Latin America and the Caribbean)
   <<: *DEFAULT_ES
-es-CO:
+es-AR: #Spanish (Argentina)
+  <<: *DEFAULT_ES
+es-BO: #Spanish (Bolivia)
+  <<: *DEFAULT_ES
+es-BR: #Spanish (Brazil)
+  <<: *DEFAULT_ES
+es-BZ: #Spanish (Belize)
+  <<: *DEFAULT_ES
+es-CL: #Spanish (Chile)
+  <<: *DEFAULT_ES
+es-CO: #Spanish (Colombia)
+  <<: *DEFAULT_ES
+es-CR: #Spanish (Costa Rica)
+  <<: *DEFAULT_ES
+es-CU: #Spanish (Cuba)
+  <<: *DEFAULT_ES
+es-DO: #Spanish (Dominican Republic)
+  <<: *DEFAULT_ES
+es-EC: #Spanish (Ecuador)
+  <<: *DEFAULT_ES
+es-ES: #Spanish (Spain)
+  <<: *DEFAULT_ES
+es-GQ: #Spanish (Equatorial Guinea)
+  <<: *DEFAULT_ES
+es-GT: #Spanish (Guatemala)
+  <<: *DEFAULT_ES
+es-HN: #Spanish (Honduras)
+  <<: *DEFAULT_ES
+es-MX: #Spanish (Mexico)
+  <<: *DEFAULT_ES
+es-NI: #Spanish (Nicaragua)
+  <<: *DEFAULT_ES
+es-PA: #Spanish (Panama)
+  <<: *DEFAULT_ES
+es-PE: #Spanish (Peru)
+  <<: *DEFAULT_ES
+es-PH: #Spanish (Philippines)
+  <<: *DEFAULT_ES
+es-PR: #Spanish (Puerto Rico)
+  <<: *DEFAULT_ES
+es-PY: #Spanish (Paraguay)
+  <<: *DEFAULT_ES
+es-SV: #Spanish (El Salvador)
+  <<: *DEFAULT_ES
+es-US: #Spanish (United States)
+  <<: *DEFAULT_ES
+es-UY: #Spanish (Uruguay)
+  <<: *DEFAULT_ES
+es-VE: #Spanish (Venezuela)
   <<: *DEFAULT_ES
 
-# Deutsch
+# Deutsch (https://localizely.com/language-code/de/)
 # -----------------
 de: &DEFAULT_DE
   nav:
@@ -75,5 +323,18 @@ de: &DEFAULT_DE
       section: Kontakt
     - title: "Quellcode des Themas"
       url: https://github.com/raviriley/agency-jekyll-theme/
-de-DE:
+
+de-AT: #German (Austria)
+  <<: *DEFAULT_DE
+de-BE: #German (Belgium)
+  <<: *DEFAULT_DE
+de-CH: #German (Switzerland)
+  <<: *DEFAULT_DE
+de-DE: #German (Germany)
+  <<: *DEFAULT_DE
+de-IT: #German (Italy)
+  <<: *DEFAULT_DE
+de-LI: #German (Liechtenstein)
+  <<: *DEFAULT_DE
+de-LU: #German (Luxembourg)
   <<: *DEFAULT_DE


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add all individual country entries for the translated languages (`en`, `es`, `de`).

## Context

Add all countries for English, Spanish, and Deutsch using the following reference: https://localizely.com/iso-639-1-list/.

Not related to any issue, just extending the list of countries per translated languages.
