### PR TITLE
Make logo image option for the title responsive

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,12 @@ title      : Your Awesome Website
 email      : your-email@example.com #this is also the email contact forms will go to
 description: "Site description"
 author     : Your Name
-# logo:     #optional, defaults to site title
-  # path: assets\img\clients\creative-market.jpg
-  # height: 60 #height in px, defaults to 52px
+# logo: # Optional, defaults to site title
+  # path: assets/img/logo.png
+  # # Optional image heights. Defaults are 38px/28px (max/min) which are approx
+  # # heights of title text at 1.75rem/1.25rem.
+  # max-height: 60px #used on big screens.
+  # min-height: 40px #small screens, and when the nav bar shrinks after scrolling.
 
 locale: "en-US" # See available languages in _data/sitetext.yml
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -6,11 +6,7 @@
 >
   <div class="container">
     <a class="navbar-brand js-scroll-trigger" href="{{ site.baseurl }}/#">
-      {%- if site.logo -%}
-      <img
-        height="{{ site.logo.height | default: 52 }}"
-        src="{{ site.logo.path }}"
-      />
+      {%- if site.logo -%} <img src="{{ site.logo.path }}" />
       {%- else -%} {{ site.title }} {%- endif -%}
     </a>
     <button

--- a/_includes/navheader.html
+++ b/_includes/navheader.html
@@ -1,12 +1,9 @@
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
     <div class="container">
-	  <a class="navbar-brand js-scroll-trigger" href="#page-top">
-          {%- if site.logo -%}
-            <img height="{{ site.logo.height | default: 52 }}" src="{{ site.logo.path }}"/>
-          {%- else -%}
-            {{ site.title }}
-          {%- endif -%}
+      <a class="navbar-brand js-scroll-trigger" href="#page-top">
+        {%- if site.logo -%} <img src="{{ site.logo.path }}" />
+        {%- else -%} {{ site.title }} {%- endif -%}
       </a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         Menu

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -1,3 +1,11 @@
+//in case an image is provided instead of text
+@mixin brand-img($height) {
+  img { //height is not inherited by img, so set it on that tag explicity.
+    height: $height;
+    transition: all 0.3s;
+  }
+}
+
 // Styling for the navbar
 #mainNav {
   background-color: $gray-900;
@@ -14,6 +22,7 @@
   .navbar-brand {
     color: $primary;
     @include script-font;
+    @include brand-img($logo-height-min);
     &.active,
     &:active,
     &:focus,
@@ -49,6 +58,7 @@
     background-color: transparent;
     .navbar-brand {
       font-size: 1.75em;
+      @include brand-img($logo-height-max);
       -webkit-transition: all 0.3s;
       -moz-transition: all 0.3s;
       transition: all 0.3s;
@@ -66,6 +76,7 @@
       background-color: $gray-900;
       .navbar-brand {
         font-size: 1.25em;
+        @include brand-img($logo-height-min);
         padding: 12px 0;
       }
     }

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -25,6 +25,10 @@ $black: {{ site.data.style.black | default: "#000" }} !default;
 $header-image: "{{ site.data.style.header-image }}";
 $contact-image: "{{ site.data.style.contact-image }}";
 
+// Logo parameters for the navbar-brand class, in case a logo is provided instead of text
+$logo-height-min: {{ site.logo.min-height | default: "28px" }};
+$logo-height-max: {{ site.logo.max-height | default: "38px" }};
+
 // Global CSS
 @import "base/page.scss";
 


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Apply the responsiveness that the title text exhibits to the logo if the user opts to use a logo instead.

## Context

The user has the option to specify a logo image to use in place of the title text in the "brand" section of the nav bar at the top left of the page.

However, the responsiveness of the title text is not carried over. This PR attempts to rectify that by applying the same behaviour.

Specifically, the user may now specify a min/max height instead of a single height. The defaults are based on the heights of the title text (at least by my measurements in Arc on a MacBook).

Instead of using the height as a fixed, unitless HTML property, they are required to have units and are propagated through to Sass like other user settings. There they are applied everywhere "font-size" is applied to the title text (id: `navbar-brand`). That is:

1. The min size by default
2. The max size if screen width is min 992px.
3. The min size once the page is scrolled down a bit and the nav bar shrinks.

The same transitions from the text style have also been carried over.

## Known caveats

- This is potentially a **breaking change**. If the user already had a logo `height` specified, it will be ignored and defaults applied instead. The user must specify `min-height` and `max-height` instead.
- The existing implementation sets style (`height`) in `_config.yml` even though other images are specified in `style.yml`. It makes sense why, since it overrides `title`, which is in `_config.yml`, so I haven't attempted to change it.
- I've never used Sass before (or Jekyll for that matter). I've attempted to follow the existing conventions and keep things neat, but may be missing some knowledge here.
- The `logo` feature is not used in the demo/tests, so the impact is not immediately obvious. I tested by temporarily changing `_config.yml` and adding a suitable image to `assets`. You can use [my site](https://github.com/hraftery/bike_bus_network) as a reference implementation.