### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gemspec
 # Delete the following lines if not on Windows: 
 # Performance-booster for watching directories on Windows
 gem "wdm", ">= 0.1.0" if Gem.win_platform?
+
+# Prevent warning about logger not being a default gem in the future.
+gem "logger", "~> 1.6.4"

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@
 # in the templates via {{ site.myvariable }}.
 
 theme: jekyll-agency
+sass:
+  silence_deprecations: [import]
 
 url    : "" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_sass/base/_page.scss
+++ b/_sass/base/_page.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Global styling for this template
 body {
   overflow-x: hidden;
@@ -11,7 +13,7 @@ p {
 a {
   color: $primary;
   &:hover {
-    color: darken($primary, 10%);
+    color: color.adjust($primary, $lightness: -10%);
   }
 }
 

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Button Styles
 .btn {
   @include heading-font;
@@ -15,8 +17,8 @@
   &:active,
   &:focus,
   &:hover {
-    background-color: darken($primary, 7.5%) !important;
-    border-color: darken($primary, 7.5%) !important;
+    background-color: color.adjust($primary, $lightness: -7.5%) !important;
+    border-color: color.adjust($primary, $lightness: -7.5%) !important;
     color: white;
   }
   &:active,

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Styling for the navbar
 #mainNav {
   background-color: $gray-900;
@@ -18,7 +20,7 @@
     &:active,
     &:focus,
     &:hover {
-      color: darken($primary, 10%);
+      color: color.adjust($primary, $lightness: -10%);
     }
   }
   .navbar-nav {

--- a/_sass/layout/_portfolio.scss
+++ b/_sass/layout/_portfolio.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Styling for the portfolio section
 #portfolio {
   .portfolio-item {
@@ -17,7 +19,7 @@
         -moz-transition: all ease 0.5s;
         transition: all ease 0.5s;
         opacity: 0;
-        background: fade-out($primary, 0.1);
+        background: color.adjust($primary, $alpha: -0.1); //fade-out
         &:hover {
           opacity: 1;
         }

--- a/_sass/layout/_team.scss
+++ b/_sass/layout/_team.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Styling for the team section
 .team-member {
   margin-bottom: 50px;
@@ -5,7 +7,7 @@
   img {
     width: 225px;
     height: 225px;
-    border: 7px solid fade-out($black, 0.9);
+    border: 7px solid color.adjust($black, $alpha: -0.9); //fade-out
   }
   h4 {
     margin-top: 25px;


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Suppresses "ignore", "global built-in" deprecation warnings introduced in Sass 1.80.0.

## Context

Resolves https://github.com/raviriley/agency-jekyll-theme/issues/92

In summary:

1. Resolved the global built-in warnings by making the recommended substitutions.
2. Suppressed the import warnings by adding `silence_deprecations`.
3. Also added logger explicitly in the gemfile, to suppress another warning about it being removed from the default gems in Ruby 4.0.0.
